### PR TITLE
Update shortened URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ When a pull request is merged, Travis CI performs the build and writes the resul
 The `gh-pages` branch hosts the following URLs:
 
 + **HTML manuscript** at https://greenelab.github.io/manubot-rootstock/<br>
-  short URL: https://git.io/vytJN
+  short URL: https://git.io/vQPp1
 + **PDF manuscript** at https://greenelab.github.io/manubot-rootstock/manuscript.pdf<br>
-  short URL: https://git.io/vytJ5
+  short URL: https://git.io/vQPp7
 
 For continuous integration configuration details, see [`.travis.yml`](.travis.yml).
 


### PR DESCRIPTION
While working through the process outlined in #6 I noticed the short URLs still pointed to deep-review