### PR TITLE
Use same locale for all builds

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,5 +1,8 @@
 set -o errexit
 
+# Default Python to read/write text files using UTF-8 encoding
+export LC_ALL=en_US.UTF-8
+
 # Generate reference information
 echo "Retrieving and processing reference metadata"
 (cd build && python references.py)


### PR DESCRIPTION
Fixes issue reported in https://github.com/greenelab/deep-review/pull/569 where some OSes use a non-UTF-8 default encoding.

CC @yfpeng