### PR TITLE
Fix citeproc issue with catagories

### DIFF
--- a/build/citations.py
+++ b/build/citations.py
@@ -146,6 +146,8 @@ citeproc_remove_keys = [
     'event',
     # remove the references of cited papers. Not neccessary and unwieldy.
     'reference',
+    # Error in $[26].categories[0][0]: failed to parse field categories: mempty
+    'categories',
 ]
 
 


### PR DESCRIPTION
Full error:

```
pandoc-citeproc: Error in $[26].categories[0][0]: failed to parse field categories: mempty
CallStack (from HasCallStack):
  error, called at src/Text/CSL/Input/Bibutils.hs:50:49 in pandoc-citeproc-0.10.4-36ROWpY3Inr1fCxMvEajRL:Text.CSL.Input.Bibutils
pandoc: Error running filter pandoc-citeproc
```