### PR TITLE
Write source repo version info in manucript

### DIFF
--- a/build/references.py
+++ b/build/references.py
@@ -162,6 +162,16 @@ authors = metadata.pop('author_info')
 metadata['author'] = [author['full_name'] for author in authors]
 stats['authors'] = authors
 
+# Set repository version metadata for CI builds only
+repo_slug = os.getenv('TRAVIS_REPO_SLUG')
+commit = os.getenv('TRAVIS_COMMIT')
+if repo_slug and commit:
+    stats['ci_source'] = {
+        'repo_slug': repo_slug,
+        'commit': commit,
+    }
+
+# Write stats to JSON
 with gen_dir.joinpath('stats.json').open('wt') as write_file:
     json.dump(stats, write_file, indent=2)
 

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -1,3 +1,9 @@
+{% if ci_source is defined %}
+<small><em>
+This manuscript was automatically generated from [{{ci_source.repo_slug}}@{{ci_source.commit | truncate(length=7, end='', leeway=0)}}](https://github.com/{{ci_source.repo_slug}}/commit/{{ci_source.commit}}).
+</em></small>
+{% endif %}
+
 ## Authors
 
 {% for author in authors %}


### PR DESCRIPTION
Only applies to manuscripts built on Travis. Creates a header under the title with version information. Therefore, given a manuscript that's built via Travis, you can always get back to the source:

![commit-in-manuscript](https://user-images.githubusercontent.com/1117703/28250672-8942578e-6a3c-11e7-8e4e-ce047147cad2.png)

Also will help alert readers to the online source and manubot system.