### PR TITLE
Shorten & simplify metadata author keys

### DIFF
--- a/build/references.py
+++ b/build/references.py
@@ -159,7 +159,7 @@ with path.open() as read_file:
 
 # Author table information
 authors = metadata.pop('author_info')
-metadata['author'] = [author['full_name'] for author in authors]
+metadata['author'] = [author['name'] for author in authors]
 stats['authors'] = authors
 
 # Set repository version metadata for CI builds only

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -7,18 +7,18 @@ This manuscript was automatically generated from [{{ci_source.repo_slug}}@{{ci_s
 ## Authors
 
 {% for author in authors %}
-+ **{{author.full_name}}**<br>
++ **{{author.name}}**<br>
   {%- if author.orcid is defined %}
     ![ORCID icon](images/orcid.svg){height="13px"}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
   {%- endif %}
-  {%- if author.github_username is defined %}
+  {%- if author.github is defined %}
     · ![GitHub icon](images/github.svg){height="13px"}
-    [{{author.github_username}}](https://github.com/{{author.github_username}})
+    [{{author.github}}](https://github.com/{{author.github}})
   {%- endif %}
-  {%- if author.twitter_username is defined %}
+  {%- if author.twitter is defined %}
     · ![Twitter icon](images/twitter.svg){height="13px"}
-    [{{author.twitter_username}}](https://twitter.com/{{author.twitter_username}})
+    [{{author.twitter}}](https://twitter.com/{{author.twitter}})
   {%- endif %}<br>
   <small>
   {%- if author.affiliations is defined %}

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -7,30 +7,30 @@ keywords:
   - publishing
 author_info:
   -
-    github_username: dhimmel
-    full_name: Daniel S. Himmelstein
+    github: dhimmel
+    name: Daniel S. Himmelstein
     initials: DSH
     orcid: 0000-0002-3012-7446
-    twitter_username: dhimmel
+    twitter: dhimmel
     email: daniel.himmelstein@gmail.com
     affiliations: Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania
     funders: GBMF4552
   -
-    github_username: agitter
-    full_name: Anthony Gitter
+    github: agitter
+    name: Anthony Gitter
     initials: AG
     orcid: 0000-0002-5324-9833
     email: gitter@biostat.wisc.edu
     affiliations: Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison and Morgridge Institute for Research
     funders: NIH U54AI117924
   -
-    github_username: vsmalladi
-    full_name: Venkat S. Malladi
+    github: vsmalladi
+    name: Venkat S. Malladi
     initials: VSM
     orcid: 0000-0002-0144-0564
     email: vsmalladi@gmail.com
     affiliations: The Laboratory of Signaling and Gene Expression, Cecil H. and Ida Green Center for Reproductive Biology Sciences, University of Texas Southwestern Medical Center
   -
-    github_username: evancofer
-    full_name: Evan M. Cofer
+    github: evancofer
+    name: Evan M. Cofer
     initials: EMC


### PR DESCRIPTION
I think our keys for author information were too verbose, especially since the YAML format requires lot's of repetition of these keys.

Since all changes to existing keys in `metadata.yaml` are breaking changes for manubot instances, we should do them sooner rather than later.