### PR TITLE
Use meta-author / meta-date to remove sed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Generated manuscript output files
 output/index.html
 output/manuscript.pdf
+output/manuscript.docx
 output/*.ots
 
 # Generated reference files

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,11 +35,6 @@ pandoc --verbose \
   --output=output/index.html \
   $INPUT_PATH
 
-# Remove h2 author names and h3 date from HTML body but
-# keep as metadata in the head.
-sed --in-place '/<h2 class="author">/d' output/index.html
-sed --in-place '/<h3 class="date"/d' output/index.html
-
 # Create PDF output
 echo "Exporting PDF manuscript"
 wkhtmltopdf \

--- a/build/references.py
+++ b/build/references.py
@@ -161,12 +161,12 @@ with path.open() as read_file:
 # Add date to metadata
 today = datetime.date.today()
 today = today.strftime('%B %e, %Y')
-metadata['date'] = today
+metadata['meta-date'] = today
 stats['date'] = today
 
 # Author table information
 authors = metadata.pop('author_info')
-metadata['author'] = [author['name'] for author in authors]
+metadata['meta-author'] = [author['name'] for author in authors]
 stats['authors'] = authors
 
 # Set repository version metadata for CI builds only

--- a/build/references.py
+++ b/build/references.py
@@ -160,13 +160,12 @@ with path.open() as read_file:
 
 # Add date to metadata
 today = datetime.date.today()
-today = today.strftime('%B %e, %Y')
-metadata['meta-date'] = today
-stats['date'] = today
+metadata['date-meta'] = today.isoformat()
+stats['date'] = today.strftime('%B %e, %Y')
 
 # Author table information
 authors = metadata.pop('author_info')
-metadata['meta-author'] = [author['name'] for author in authors]
+metadata['author-meta'] = [author['name'] for author in authors]
 stats['authors'] = authors
 
 # Set repository version metadata for CI builds only


### PR DESCRIPTION
Thanks @tarleb for the tip, which I couldn't find in the pandoc docs. This is a much preferable to sed. Especially since it works for DOCX output!