### PR TITLE
Set print margin-top and margin-bottom

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -40,8 +40,10 @@ echo "Exporting PDF manuscript"
 wkhtmltopdf \
   --quiet \
   --print-media-type \
-  --margin-top 22 \
-  --margin-bottom 20 \
+  --margin-top 21 \
+  --margin-bottom 17 \
+  --margin-left 0 \
+  --margin-right 0 \
   output/index.html \
   output/manuscript.pdf
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -39,6 +39,9 @@ pandoc --verbose \
 echo "Exporting PDF manuscript"
 wkhtmltopdf \
   --quiet \
+  --print-media-type \
+  --margin-top 22 \
+  --margin-bottom 20 \
   output/index.html \
   output/manuscript.pdf
 

--- a/output/github-pandoc.css
+++ b/output/github-pandoc.css
@@ -77,10 +77,7 @@ body {
     margin: 0;
 }
 
-/* 
- * Page margins when printing
- * https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2982#issuecomment-308714479
- */
+/***Page margins when printing***/
 @page { 
     margin-top: 22mm;
     margin-bottom: 20mm;

--- a/output/github-pandoc.css
+++ b/output/github-pandoc.css
@@ -79,8 +79,10 @@ body {
 
 /***Page margins when printing***/
 @page { 
-    margin-top: 22mm;
-    margin-bottom: 20mm;
+    margin-top: 19mm;
+    margin-bottom: 16mm;
+    margin-left: 0mm;
+    margin-right: 0mm;
 }
 
 /* 

--- a/output/github-pandoc.css
+++ b/output/github-pandoc.css
@@ -77,13 +77,21 @@ body {
     margin: 0;
 }
 
+/* 
+ * Page margins when printing
+ * https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2982#issuecomment-308714479
+ */
+@page { 
+    margin-top: 22mm;
+    margin-bottom: 20mm;
+}
 
 /* 
  * Page Breaks
  * https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2982#issuecomment-308714479
  */
 
-@media screen, print {
+@media print {
   /***Always insert a page break before the element***/
   .page_break_before {
       page-break-before: always !important;


### PR DESCRIPTION
Closes https://github.com/greenelab/manubot-rootstock/issues/38

With this PR, here's what the PDFs look like:

+ generated in `build.sh`: [manuscript-wkhtmltopdf.pdf](https://github.com/greenelab/manubot-rootstock/files/1166592/manuscript-wkhtmltopdf.pdf)
+ print preview in chrome on linux [manuscript-chrome-linux.pdf](https://github.com/greenelab/manubot-rootstock/files/1166598/manuscript-chrome-linux.pdf)

Note that I added a section (not tracked) with lorem ipsum text.

Also `--print-media-type` gets rid of border from the `wkhtmltopdf` PDF.