### PR TITLE
Add word count

### DIFF
--- a/build/references.py
+++ b/build/references.py
@@ -177,10 +177,6 @@ if repo_slug and commit:
         'commit': commit,
     }
 
-# Write stats to JSON
-with gen_dir.joinpath('stats.json').open('wt') as write_file:
-    json.dump(stats, write_file, indent=2)
-
 # Convert to citation_id citations for pandoc
 converted_text = text
 for old, new in zip(ref_df.text, ref_df.citation_id):
@@ -197,6 +193,14 @@ jinja_environment = jinja2.Environment(
 )
 template = jinja_environment.from_string(converted_text)
 converted_text = template.render(**stats)
+
+# Get word count
+stats['word_count'] = len(converted_text.split())
+print(f'Word count: {stats["word_count"]}')
+
+# Write stats to JSON
+with gen_dir.joinpath('stats.json').open('wt') as write_file:
+    json.dump(stats, write_file, indent=2)
 
 # Write manuscript for pandoc
 all_sections_path = gen_dir.joinpath('all-sections.md')


### PR DESCRIPTION
Having a word count would be a convenience for anyone writing a manuscript that imposes word limits.  It is not obvious what should be counted.  For now, I count all whitespace-separated strings after rendering the Jinja2 templates.

The build output is:
```
Using metadata cache: True
3 unique citations strings extracted from text
2 unique citations after standardizations
standard_citation                 text
doi:10.1101/142760  @doi:10.1101/142760
doi:10.1101/142760     @tag:deep_review
References by type:
Counter({'total': 2, 'doi': 1, 'url': 1})
Word count: 323
Exporting HTML manuscript
Exporting PDF manuscript
```

If I copy and paste the HTML into Word, it gives a count of 306.  Word might be ignoring figures and tables, but I didn't probe the cause.