### PR TITLE
Set timezone to UTC in build.sh

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -120,6 +120,7 @@ For guidance on what CSL JSON should be like for different document types, refer
 [`content/metadata.yaml`](content/metadata.yaml) contains manuscript metadata that gets passed through to Pandoc, via a [`yaml_metadata_block`](http://pandoc.org/MANUAL.html#extension-yaml_metadata_block).
 `metadata.yaml` should contain the manuscript `title`, `authors` list, and `keywords`.
 Additional metadata, such as `date`, will automatically be created by the Manubot.
+Manubot uses the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) specified in [`build.sh`](build/build.sh) for setting the manuscript's date. For example, setting the `TZ` environment variable to `Etc/UTC` directs the Manubot to use Coordinated Universal Time.
 
 We recommend authors add themselves to `metadata.yaml` via pull request (when requested by a maintainer), thereby signaling that they've read and approved the manuscript.
 The following YAML shows the supported key–value pairs for an author:  

--- a/USAGE.md
+++ b/USAGE.md
@@ -120,7 +120,8 @@ For guidance on what CSL JSON should be like for different document types, refer
 [`content/metadata.yaml`](content/metadata.yaml) contains manuscript metadata that gets passed through to Pandoc, via a [`yaml_metadata_block`](http://pandoc.org/MANUAL.html#extension-yaml_metadata_block).
 `metadata.yaml` should contain the manuscript `title`, `authors` list, and `keywords`.
 Additional metadata, such as `date`, will automatically be created by the Manubot.
-Manubot uses the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) specified in [`build.sh`](build/build.sh) for setting the manuscript's date. For example, setting the `TZ` environment variable to `Etc/UTC` directs the Manubot to use Coordinated Universal Time.
+Manubot uses the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) specified in [`build.sh`](build/build.sh) for setting the manuscript's date.
+For example, setting the `TZ` environment variable to `Etc/UTC` directs the Manubot to use Coordinated Universal Time.
 
 We recommend authors add themselves to `metadata.yaml` via pull request (when requested by a maintainer), thereby signaling that they've read and approved the manuscript.
 The following YAML shows the supported key–value pairs for an author:  

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,5 +1,7 @@
 set -o errexit
 
+# Set timezone used by Python for setting the manuscript's date
+export TZ=Etc/UTC
 # Default Python to read/write text files using UTF-8 encoding
 export LC_ALL=en_US.UTF-8
 

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pip:
     - errorhandler==2.0.1
     - ghp-import==0.5.5
-    - git+https://github.com/greenelab/manubot@1723a22ebb7dce98e60fd748f4e6c5380e6ce08c
+    - git+https://github.com/greenelab/manubot@e040b9dbb0af250669df77501b046a2edc7942f5
     - pandoc-eqnos==0.16
     - pandoc-fignos==0.20
     - pandoc-tablenos==0.16


### PR DESCRIPTION
Closes https://github.com/greenelab/manubot/issues/3

Specifying `TZ` in `build.sh` rather than `.travis.yml`, has the benefit of effecting local builds as well.

Tagging @slochower 