### PR TITLE
Explicitly insert bibliography

### DIFF
--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -1,1 +1,4 @@
 ## References {.page_break_before}
+
+<!-- Explicitly insert bibliography here -->
+<div id="refs"></div>


### PR DESCRIPTION
Enables content that follows the bibliography

From https://github.com/jgm/pandoc-citeproc/blame/5a7f26b61c8577916093851cdeb31fa9a198edcb/man/pandoc-citeproc.1.md#L126-L128

> a bibliography will be inserted into each Div element with id refs. If there is no such Div, one will be created at the end of the document.