### PR TITLE
Pin miniconda version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ branches:
   only:
     - master
 before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh
     --output-document miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update --quiet conda
   - conda info --all
 install:
   - conda env create --quiet --file build/environment.yml


### PR DESCRIPTION
Do not use latest miniconda, since updates can cause bugs, which happened at https://github.com/greenelab/manubot-rootstock/pull/75#issuecomment-332914877. [Solution](https://stackoverflow.com/a/46457813/4651668) by @jriehl:

> It looks like Anaconda had a new release (4.3.27) that sets the C compiler path to a non-existing executable (quite an embarrassing bug; I'm sure they'll fix it soon). I had a similar issue with pip installing using the latest Miniconda, which I fixed by using the 4.3.21 version and ensuring I was not doing something like `conda update conda`.

