### PR TITLE
Enable PubMed ID citations

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -76,9 +76,10 @@ Therefore, citations must be of the following form: `@source:identifier`, where 
 When choosing which source to use for a citation, we recommend the following order:
 
 1. DOI (Digital Object Identifier), cite like `@doi:10.15363/thinklab.4`.
-2. PubMed ID, cite like `@pmid:26158728`.
-3. _arXiv_ ID, cite like `@arxiv:1508.06576v2`.
-4. URL / webpage, cite like `@url:http://openreview.net/pdf?id=Sk-oDY9ge`.
+2. PubMed Central ID, cite like `@pmcid:PMC4497619`.
+3. PubMed ID, cite like `@pmid:26158728`.
+4. _arXiv_ ID, cite like `@arxiv:1508.06576v2`.
+5. URL / webpage, cite like `@url:http://openreview.net/pdf?id=Sk-oDY9ge`.
 
 Cite multiple items at once like:
 
@@ -87,6 +88,8 @@ Here is a sentence with several citations [@doi:10.15363/thinklab.4; @pmid:26158
 ```
 
 Note that multiple citations must be semicolon separated.
+Be careful not to cite the same study using identifiers from multiple sources.
+For example, the following citations all refer to the same study, but will be treated as separate references: `[@doi:10.7717/peerj.705; @pmcid:PMC4304851; @pmid:25648772]`.
 
 #### Citation tags
 

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - conda-forge::watchdog=0.8.3
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/greenelab/manubot@33ff36728e23f3c685f3b00a6a26f19a6fcbf68e
+    - git+https://github.com/greenelab/manubot@b53f487026954729ce80ca963f3838ebca85a144
     - opentimestamps-client==0.5.1
     - opentimestamps==0.2.0.1
     - pandoc-eqnos==1.0.0


### PR DESCRIPTION
`pmcid` citations are higher suggested priority than `pmid` citations, because I think it's likely that the NCBI Citation Exporter will return higher quality metadata with greater reliability than our E-Utilities to CSL functionality.

Upgrade Manubot to https://github.com/greenelab/manubot/commit/b53f487026954729ce80ca963f3838ebca85a144

Refs https://github.com/greenelab/manubot/pull/24