### PR TITLE
Webpage: specify letter page size in CSS

### DIFF
--- a/webpage/github-pandoc.css
+++ b/webpage/github-pandoc.css
@@ -87,8 +87,9 @@ body {
     margin: 0;
 }
 
-/***Page margins when printing***/
-@page { 
+/***Page size and margins when printing***/
+@page {
+    size: Letter;
     margin-top: 19mm;
     margin-bottom: 16mm;
     margin-left: 0mm;


### PR DESCRIPTION
Closes https://github.com/greenelab/manubot-rootstock/issues/105

At least for the Sci-Hub manuscript this change increased the length (number of pages). See the letter manuscript at [manuscript.pdf](https://github.com/greenelab/manubot-rootstock/files/1685322/manuscript.pdf).

> Changing to letter by default seems okay. In the usage we can note or link to instructions for setting it back to A4.

@agitter going to skip adding instructions to USAGE, since I'm not sure of our longterm plans regarding the CSS and how it should be edited. Also hopefully users will be able to now more easily search for https://github.com/greenelab/manubot-rootstock/issues/105 if they're curious.