### PR TITLE
Fix name with space issue

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -15,7 +15,7 @@ ots stamp \
 # Configure git
 git config --global push.default simple
 git config --global user.email `git log --max-count=1 --format='%ae'`
-git config --global user.name `git log --max-count=1 --format='%an'`
+git config --global user.name "`git log --max-count=1 --format='%an'`"
 git checkout $TRAVIS_BRANCH
 git remote set-url origin git@github.com:$TRAVIS_REPO_SLUG.git
 


### PR DESCRIPTION
git's user.name config was being set to first names only, since names are space separated. Add quotes to prevent this.

example before:

```
$ git log
commit 8b6861af46df7ec2664aca2d2d5e08a0bf3bb238 (HEAD -> gh-pages, upstream/gh-pages)
Author: Daniel <daniel.himmelstein@gmail.com>
Date:   Wed Jan 24 18:34:49 2018 +0000
```