### PR TITLE
autobuild.sh: include webpage.py execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@ Then, you can build the manuscript on POSIX systems by running the following com
 # Activate the manubot conda environment (assumes conda version >= 4.4)
 conda activate manubot
 
-# Build the manuscript
+# Build the manuscript, saving outputs to the output directory
 sh build/build.sh
-
-# Or monitor the content directory, and automatically rebuild the manuscript
-# when a change is detected.
-sh build/autobuild.sh
 
 # At this point, the HTML & PDF outputs will have been created. The remaining
 # commands are for serving the webpage to view the HTML manuscript locally.
@@ -62,6 +58,13 @@ python build/webpage.py
 # View the manuscript locally at http://localhost:8000/
 cd webpage
 python -m http.server
+```
+
+Sometimes it's helpful to monitor the content directory and automatically rebuild the manuscript when a change is detected.
+The following command, while running, will trigger both the `build.sh` and `webpage.py` scripts upon content changes:
+
+```sh
+sh build/autobuild.sh
 ```
 
 ### Continuous Integration

--- a/build/autobuild.sh
+++ b/build/autobuild.sh
@@ -1,6 +1,6 @@
-# Automatically rebuild manuscript when content changes
+# Automatically rebuild mansucript outputs and the webpage when content changes
 # Depends on watchdog https://github.com/gorakhargosh/watchdog
 watchmedo shell-command \
   --wait \
-  --command='sh build/build.sh' \
+  --command='sh build/build.sh && python build/webpage.py' \
   content


### PR DESCRIPTION
Most autobuild users will want to automatically update the webpage. See discussion at
https://github.com/greenelab/manubot-rootstock/pull/101#issuecomment-366405495

Update README to better document autobuild.

@slochower can you take a look and confirm that this does what you want it to?