### PR TITLE
front matter: hyperlink permalink for brevity

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -10,14 +10,15 @@ _A DOI-citable version of this manuscript is available at <https://doi.org/DOI_H
 
 {## Template to insert build date and source ##}
 <small><em>
-This manuscript was automatically generated
+This manuscript
+{% if ci_source is defined -%}
+([permalink](https://{{ci_source.repo_owner}}.github.io/{{ci_source.repo_name}}/v/{{ci_source.commit}}/))
+{% endif -%}
+was automatically generated
 {% if ci_source is defined -%}
 from [{{ci_source.repo_slug}}@{{ci_source.commit | truncate(length=7, end='', leeway=0)}}](https://github.com/{{ci_source.repo_slug}}/tree/{{ci_source.commit}})
 {% endif -%}
 on {{date}}.
-{% if ci_source is defined -%}
-The permalink for this manuscript version is <https://{{ci_source.repo_owner}}.github.io/{{ci_source.repo_name}}/v/{{ci_source.commit}}/>.
-{% endif -%}
 </em></small>
 
 ## Authors


### PR DESCRIPTION
The preambles were getting a bit long. For example, see https://greenelab.github.io/scihub-manuscript/v/8e538a98e4f16bab632c00efb1fb4f1b23a1c122/

> ![not-brevity](https://user-images.githubusercontent.com/1117703/36688167-979b7086-1af9-11e8-955a-17504f7b3879.png)