### PR TITLE
Upgrade miniconda on Travis to 4.4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ branches:
   only:
     - master
 before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh
     --output-document miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+  - source $HOME/miniconda/etc/profile.d/conda.sh
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda info --all
 install:
   - conda env create --quiet --file build/environment.yml
-  - source activate manubot
+  - conda activate manubot
 script:
   - sh build/build.sh
 cache:


### PR DESCRIPTION
The method for enabling conda has changed. See [4.4 release notes](https://github.com/conda/conda/blob/53954c0d6785510587cd755a0cee4e177dca8455/CHANGELOG.md#recommended-change-to-enable-conda-in-your-shell).

Refs https://github.com/greenelab/manubot-rootstock/pull/97#discussion_r160516479