### PR TITLE
CSL: do not collapse numeric citations

### DIFF
--- a/build/assets/style.csl
+++ b/build/assets/style.csl
@@ -34,7 +34,7 @@
       </else-if>
     </choose>
   </macro>
-  <citation collapse="citation-number">
+  <citation>
     <sort>
       <key variable="citation-number"/>
     </sort>


### PR DESCRIPTION
Change style of citations from [1–4] to [1,2,3,4]

Part of https://github.com/greenelab/manubot-rootstock/issues/118
Refs https://github.com/citation-style-language/schema/issues/150

Thanks @rmzelle for the tip how to make this change!