### PR TITLE
build.sh: remove long args incompatible with macOS

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -44,7 +44,7 @@ pandoc --verbose \
 
 # Create PDF output
 echo "Exporting PDF manuscript"
-ln --symbolic content/images images
+ln -s content/images images
 pandoc \
   --from=markdown \
   --to=html5 \
@@ -60,7 +60,7 @@ pandoc \
   --css=webpage/github-pandoc.css \
   --output=output/manuscript.pdf \
   $INPUT_PATH
-rm --recursive images
+rm -r images
 
 # Create DOCX output when user specifies to do so
 if [ "$BUILD_DOCX" = "true" ];


### PR DESCRIPTION
Refs https://github.com/greenelab/manubot-rootstock/issues/120

CC @adebali @vsmalladi