### PR TITLE
CSL: improve whitespace in references

### DIFF
--- a/build/assets/style.csl
+++ b/build/assets/style.csl
@@ -51,7 +51,7 @@
       <group display="block">
         <text macro="author"/>
       </group>
-      <group display="block" delimiter=" ">
+      <group delimiter=" ">
         <text macro="venue" font-style="italic"/>
         <date variable="issued" prefix="(" suffix=")">
           <date-part name="year"/>
@@ -60,7 +60,7 @@
         </date>
         <text variable="URL"/>
       </group>
-      <group delimiter=" · ">
+      <group display="block" delimiter=" · ">
         <text variable="DOI" text-case="lowercase" prefix="DOI: "/>
         <text variable="PMID" prefix="PMID: "/>
         <text variable="PMCID" prefix="PMCID: "/>


### PR DESCRIPTION
Addresses issue at https://github.com/greenelab/manubot/pull/58/commits/6efe572edcff8e88d13556e5c831bbe1f9400827#r220241077

Hopefully can also address [this](https://github.com/greenelab/manubot-rootstock/pull/132#discussion_r212458417):

> is it easy to add a default value when there is no author? I'll open a separate issue if it is out of scope.

