### PR TITLE
Support BUILD_PDF=false environment variable

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -2,10 +2,13 @@
 
 [`build.sh`](build.sh) builds the repository.
 `sh build/build.sh` should be executed from the root directory of the repository.
+By default, `build.sh` creates HTML and PDF outputs.
+However, setting the `BUILD_PDF` environment variable to `false` will suppress PDF output.
+For example, run local builds using the command `BUILD_PDF=false sh build/build.sh`.
 
 To build a DOCX file of the manuscript, set the `BUILD_DOCX` environment variable to `true`.
 For example, use the command `BUILD_DOCX=true sh build/build.sh`.
-Set a [Travis environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) to export DOCX for all Travis builds.
+To export DOCX for all Travis builds, set a [Travis environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
 Currently, equation numbers via `pandoc-eqnos` are not supported for DOCX output.
 There is varying support for embedding images in DOCX output.
 Please reference [Pull Request #40](https://github.com/greenelab/manubot-rootstock/pull/40) for possible solutions and continued discussion.

--- a/build/build.sh
+++ b/build/build.sh
@@ -42,31 +42,34 @@ pandoc --verbose \
   --output=output/manuscript.html \
   $INPUT_PATH
 
-# Create PDF output
-echo "Exporting PDF manuscript"
-ln -s content/images images
-pandoc \
-  --from=markdown \
-  --to=html5 \
-  --pdf-engine=weasyprint \
-  --pdf-engine-opt=--presentational-hints \
-  --filter=pandoc-fignos \
-  --filter=pandoc-eqnos \
-  --filter=pandoc-tablenos \
-  --bibliography=$BIBLIOGRAPHY_PATH \
-  --csl=$CSL_PATH \
-  --metadata link-citations=true \
-  --webtex=https://latex.codecogs.com/svg.latex? \
-  --css=webpage/github-pandoc.css \
-  --output=output/manuscript.pdf \
-  $INPUT_PATH
-rm -r images
+# Create PDF output (unless BUILD_DOCX environment variable equals "false")
+if [ "$BUILD_PDF" != "false" ]
+then
+  echo "Exporting PDF manuscript"
+  ln -s content/images images
+  pandoc \
+    --from=markdown \
+    --to=html5 \
+    --pdf-engine=weasyprint \
+    --pdf-engine-opt=--presentational-hints \
+    --filter=pandoc-fignos \
+    --filter=pandoc-eqnos \
+    --filter=pandoc-tablenos \
+    --bibliography=$BIBLIOGRAPHY_PATH \
+    --csl=$CSL_PATH \
+    --metadata link-citations=true \
+    --webtex=https://latex.codecogs.com/svg.latex? \
+    --css=webpage/github-pandoc.css \
+    --output=output/manuscript.pdf \
+    $INPUT_PATH
+  rm -r images
+fi
 
-# Create DOCX output when user specifies to do so
+# Create DOCX output (if BUILD_DOCX environment variable equals "true")
 if [ "$BUILD_DOCX" = "true" ];
 then
-    echo "Exporting Word Docx manuscript"
-    pandoc --verbose \
+  echo "Exporting Word Docx manuscript"
+  pandoc --verbose \
     --from=markdown \
     --to=docx \
     --filter=pandoc-fignos \

--- a/build/webpage.py
+++ b/build/webpage.py
@@ -117,8 +117,11 @@ def create_version(args):
         'manuscript.pdf': 'manuscript.pdf',
     }
     for src, dst in renamer.items():
+        src_path = args.output_directory.joinpath(src)
+        if not src_path.exists():
+            continue
         shutil.copy2(
-            src=args.output_directory.joinpath(src),
+            src=src_path,
             dst=args.version_directory.joinpath(dst),
         )
 


### PR DESCRIPTION
Closes https://github.com/greenelab/manubot-rootstock/issues/122 by @rgieseke.
Relates to https://github.com/greenelab/manubot-rootstock/issues/144#issuecomment-437119645 by @trang1618.

Several users have had issues building the PDF locally, especially on macOS. This PR enables a way to disable PDF builds, since users may be OKAY with just HTML output locally. `webpage.py` has been updated so as not to fail if `manuscript.pdf` is missing.

@rgieseke a review from you would be a appreciated since I think you're familiar with this part of the code?

TODO: investigate whether OTS timestamping on travis deploy would fail without a PDF.