### PR TITLE
Add pango to conda environment

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -15,7 +15,7 @@ Please reference [Pull Request #40](https://github.com/greenelab/manubot-rootsto
 
 ## Environment
 
-**Windows not currently supported**
+Note: currently, **Windows is not supported**.
 
 Install or update the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running:
 

--- a/build/README.md
+++ b/build/README.md
@@ -15,6 +15,8 @@ Please reference [Pull Request #40](https://github.com/greenelab/manubot-rootsto
 
 ## Environment
 
+**Windows not currently supported**
+
 Install or update the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running:
 
 ```sh
@@ -26,4 +28,5 @@ conda env create --file environment.yml
 ```
 
 Activate with `conda activate manubot` (assumes `conda` version of [at least](https://github.com/conda/conda/blob/9d759d8edeb86569c25f6eb82053f09581013a2a/CHANGELOG.md#440-2017-12-20) 4.4).
-The environment should successfully install on both Linux and macOS (and possibly Windows).
+The environment should successfully install on both Linux and macOS.
+However, it will fail on Windows due to the [`pango`](https://anaconda.org/conda-forge/pango) dependency.

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - conda-forge::jsonschema=2.6.0
   - conda-forge::pandas=0.23.4
   - conda-forge::pandoc=2.3.1
+  - conda-forge::pango=1.40.14
   - conda-forge::python=3.6.5
   - conda-forge::pyyaml=3.13
   - conda-forge::requests=2.19.1


### PR DESCRIPTION
Closes https://github.com/greenelab/manubot-rootstock/issues/144

pango is required by WeasyPrint during the PDF build. While usually built-in to the OS on Linux, it is not pre-installed on macOS. macOS were installing pango using homebrew, which led to a segmentation fault error.

Pango is available on conda-forge for linux and mac:

- https://anaconda.org/conda-forge/pango
- https://github.com/conda-forge/pango-feedstock

Adding pango to environment.yml prevents conda environment installation on Windows, but has the benefits of standardizing the pango version on linux and mac platforms and preventing the mac homebrew issue.