### PR TITLE
front-matter: omit null or empty author fields

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -26,23 +26,23 @@ on {{date}}.
 {## Template for listing authors ##}
 {% for author in authors %}
 + **{{author.name}}**<br>
-  {%- if author.orcid is defined %}
+  {%- if author.orcid is defined and author.orcid is not none %}
     ![ORCID icon](images/orcid.svg){height="13px" width="13px"}
     [{{author.orcid}}](https://orcid.org/{{author.orcid}})
   {%- endif %}
-  {%- if author.github is defined %}
+  {%- if author.github is defined and author.github is not none %}
     · ![GitHub icon](images/github.svg){height="13px" width="13px"}
     [{{author.github}}](https://github.com/{{author.github}})
   {%- endif %}
-  {%- if author.twitter is defined %}
+  {%- if author.twitter is defined and author.twitter is not none %}
     · ![Twitter icon](images/twitter.svg){height="13px" width="13px"}
     [{{author.twitter}}](https://twitter.com/{{author.twitter}})
   {%- endif %}<br>
   <small>
-  {%- if author.affiliations is defined %}
+  {%- if author.affiliations is defined and author.affiliations|length %}
      {{author.affiliations | join('; ')}}
   {%- endif %}
-  {%- if author.funders is defined %}
+  {%- if author.funders is defined and author.funders|length %}
      · Funded by {{author.funders}}
   {%- endif %}
   </small>


### PR DESCRIPTION
Modify the jinja2 front-matter template logic to omit adding author metadata that is `None` (for `orcid`, `github`, and `twitter`) or an empty list (for `affiliations` and `funders`). See https://github.com/dhimmel/psb-manuscript/pull/18#discussion_r245631421 for the initial bug report.

## Testing

I tested the changes with the PSB Manuscript. [Before](https://git.dhimmel.com/psb-manuscript/v/357d509102adcc3f9807f42facde6334f36fe315/). After the changes in https://github.com/greenelab/manubot-rootstock/commit/0b58f448fa12a46d6c92a2dcef3551072df902f0 and deleting body and setting byrd's affiliations to `[]`, the following PDF was produced: [manuscript.pdf](https://github.com/greenelab/manubot-rootstock/files/2780137/manuscript.pdf).
