### PR TITLE
add html5 section wrapper tag

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -60,6 +60,7 @@ if [ "$BUILD_PDF" != "false" ]; then
     --csl=$CSL_PATH \
     --metadata link-citations=true \
     --webtex=https://latex.codecogs.com/svg.latex? \
+    --section-divs \
     --css=webpage/github-pandoc.css \
     --output=output/manuscript.pdf \
     $INPUT_PATH

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,6 +35,7 @@ pandoc --verbose \
   --csl=$CSL_PATH \
   --metadata link-citations=true \
   --mathjax \
+  --section-divs \
   --css=github-pandoc.css \
   --include-in-header=build/assets/analytics.html \
   --include-after-body=build/assets/anchors.html \


### PR DESCRIPTION
Adds command line argument top pandoc to wrap manuscript sections in the document (eg. abstract, authors, introduction, references, etc.) with the html5 `<section>` tag. This aligns with modern best practices of formatting html documents, and also allows us a bit more flexibility for styling/formatting. This shouldn't affect anything with our current CSS or javascript.